### PR TITLE
Binaries adhere to jshint policy

### DIFF
--- a/bin/dev-server.js
+++ b/bin/dev-server.js
@@ -2,12 +2,8 @@
 
 'use strict';
 
-var PouchDB = require('pouchdb');
-var COUCH_HOST = process.env.COUCH_HOST || 'http://127.0.0.1:5984';
 var HTTP_PORT = 8001;
 
-var Promise = require('bluebird');
-var request = require('request');
 var http_server = require("http-server");
 var fs = require('fs');
 var indexfile = "./test/test.js";

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -88,6 +88,11 @@ function startSelenium(callback) {
       process.exit(1);
     }
     selenium.start(opts, function(err, server) {
+      if (err) {
+        console.error('Failed to start Selenium: ' + err.message);
+        process.exit(1);
+      }
+      console.log('Started Selenium: PID %s', server.pid);
       sauceClient = wd.promiseChainRemote();
       callback();
     });

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -92,6 +92,7 @@ function startSelenium(callback) {
         console.error('Failed to start Selenium: ' + err.message);
         process.exit(1);
       }
+
       console.log('Started Selenium: PID %s', server.pid);
       sauceClient = wd.promiseChainRemote();
       callback();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "write-cloudant-password": "echo 'module.exports = [\"'$CLOUDANT_USERNAME'\", \"'$CLOUDANT_PASSWORD'\", \"'$CLOUDANT_HOST'\"];' > test/.cloudant-password.js",
     "test-node": "istanbul test ./node_modules/mocha/bin/_mocha test/test.js",
     "test-browser": "./bin/test-browser.js",
-    "jshint": "jshint -c .jshintrc lib/*.js test/test.js test/test-utils.js test/*suite*/*",
+    "jshint": "jshint -c .jshintrc lib/*.js bin/*.js test/test.js test/test-utils.js test/*suite*/*",
     "test": "npm run jshint && ./bin/run-test.sh",
     "build": "mkdir -p dist && browserify lib/index.js -o dist/pouchdb.find.js && npm run min",
     "min": "uglifyjs dist/pouchdb.find.js -mc > dist/pouchdb.find.min.js",


### PR DESCRIPTION
Add bin/* into the `jshint` npm script, and make some minor changes to pass the test (mostly declared but unused variables).