### PR TITLE
Support $TEST_DB as documented in CONTRIBUTING.md

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,8 @@ require('./test-utils');
 
 var cloudantPassword = require('./.cloudant-password');
 
-var  dbs = 'testdb' + Math.random() +
+var dbs = process.env.TEST_DB ||
+  'testdb' + Math.random() +
   ',http://' + cloudantPassword[0] + ':' + cloudantPassword[1] +
   '@' + cloudantPassword[2] + '/testdb' + Math.round(Math.random() * 100000);
 


### PR DESCRIPTION
I think you perhaps copied and pasted CONTRIBUTING.md from another project (e.g. pouchdb-upsert). Nowhere in the is project is process.env.TEST_DB actually used. We don't want to make a liar out of CONTRIBUTING.md, so this two-liner does what I think is the right thing.

(Incidentally, without this patch, I see no way to run tests only locally. How were you doing it before, @nolanlawson?)