### PR TITLE
remove buffer and crypto from browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,9 @@
     "uglify-js": "^2.4.13",
     "watchify": "^3.1.0",
     "wd": "^0.2.21"
+  },
+  "browser": {
+    "crypto": false,
+    "buffer": false
   }
 }


### PR DESCRIPTION
min+gz size before: 101568. after: 17444

We do a very similar thing in PouchDB itself; I just forgot to do it here.