### PR TITLE
(#73) - fix custom ddoc,name definitions

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
+var massageCreateIndexRequest = require('../../massageCreateIndexRequest');
+
 function createIndex(db, requestDef, callback) {
+  requestDef = massageCreateIndexRequest(requestDef);
 
   db.request({
     method: 'POST',

--- a/lib/adapters/local/create-index/index.js
+++ b/lib/adapters/local/create-index/index.js
@@ -8,13 +8,14 @@ var abstractMapper = require('../abstract-mapper');
 var localUtils = require('../utils');
 var validateIndex = localUtils.validateIndex;
 var massageIndexDef = localUtils.massageIndexDef;
+var massageCreateIndexRequest = require('../../../massageCreateIndexRequest');
 
 function upsert(db, docId, diffFun) {
   return pouchUpsert.upsert.call(db, docId, diffFun);
 }
 
 function createIndex(db, requestDef) {
-
+  requestDef = massageCreateIndexRequest(requestDef);
   var originalIndexDef = utils.clone(requestDef.index);
   requestDef.index = massageIndexDef(requestDef.index);
 

--- a/lib/massageCreateIndexRequest.js
+++ b/lib/massageCreateIndexRequest.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var utils = require('./utils');
+var clone = utils.clone;
+
+// we restucture the supplied JSON considerably, because the official
+// Mango API is very particular about a lot of this stuff, but we like
+// to be liberal with what we accept in order to prevent mental
+// breakdowns in our users
+module.exports = function (requestDef) {
+  requestDef = clone(requestDef);
+
+  if (!requestDef.index) {
+    requestDef.index = {};
+  }
+
+  ['type', 'name', 'ddoc'].forEach(function (key) {
+    if (requestDef.index[key]) {
+      requestDef[key] = requestDef.index[key];
+      delete requestDef.index[key];
+    }
+  });
+
+  if (requestDef.fields) {
+    requestDef.index.fields = requestDef.fields;
+    delete requestDef.fields;
+  }
+
+  if (!requestDef.type) {
+    requestDef.type = 'json';
+  }
+  return requestDef;
+};

--- a/test/test-suite-1/test.basic3.js
+++ b/test/test-suite-1/test.basic3.js
@@ -104,5 +104,108 @@ module.exports = function (dbType, context) {
         });
       });
     });
+
+    it('#73 should be able to create a custom index name', function () {
+      var db = context.db;
+      var index = {
+        index: {
+          fields: ["awesome"],
+          name: 'myindex',
+          ddoc: 'mydesigndoc'
+        }
+      };
+      return db.createIndex(index).then(function () {
+        return db.getIndexes();
+      }).then(function (res) {
+        var indexes = res.indexes.map(function (index) {
+          return {
+            name: index.name,
+            ddoc: index.ddoc,
+            type: index.type
+          };
+        });
+        indexes.should.deep.equal([
+          {
+            name: '_all_docs',
+            type: 'special',
+            ddoc: null
+          },
+          {
+            name: 'myindex',
+            ddoc: '_design/mydesigndoc',
+            type: 'json'
+          }
+        ]);
+        return db.get('_design/mydesigndoc');
+      });
+    });
+
+    it('#73 should be able to create a custom index, alt style', function () {
+      var db = context.db;
+      var index = {
+        index: {
+          fields: ["awesome"],
+        },
+        name: 'myindex',
+        ddoc: 'mydesigndoc'
+      };
+      return db.createIndex(index).then(function () {
+        return db.getIndexes();
+      }).then(function (res) {
+        var indexes = res.indexes.map(function (index) {
+          return {
+            name: index.name,
+            ddoc: index.ddoc,
+            type: index.type
+          };
+        });
+        indexes.should.deep.equal([
+          {
+            name: '_all_docs',
+            type: 'special',
+            ddoc: null
+          },
+          {
+            name: 'myindex',
+            ddoc: '_design/mydesigndoc',
+            type: 'json'
+          }
+        ]);
+        return db.get('_design/mydesigndoc');
+      });
+    });
+
+    it('#73 should be able to create a custom index, alt style 2', function () {
+      var db = context.db;
+      var index = {
+        name: 'myindex',
+        ddoc: 'mydesigndoc',
+        fields: ["awesome"]
+      };
+      return db.createIndex(index).then(function () {
+        return db.getIndexes();
+      }).then(function (res) {
+        var indexes = res.indexes.map(function (index) {
+          return {
+            name: index.name,
+            ddoc: index.ddoc,
+            type: index.type
+          };
+        });
+        indexes.should.deep.equal([
+          {
+            name: '_all_docs',
+            type: 'special',
+            ddoc: null
+          },
+          {
+            name: 'myindex',
+            ddoc: '_design/mydesigndoc',
+            type: 'json'
+          }
+        ]);
+        return db.get('_design/mydesigndoc');
+      });
+    });
   });
 };


### PR DESCRIPTION
There are a few things this commit does:

1. fixes #73
2. makes us more liberal in what we accept, vis-a-vis `fields`, `name`, `ddoc`, etc.

In general I think the Mango API is a bit confusing for the "create index" API,
in that it requires the `fields`, `name`, `ddoc`, and `type` fields to be
on very specific parts of the request (either on `index` or not), whereas
with pouchdb-find I prefer to be more liberal in what we accept and to reduce
user confusion by just correcting their requests for them.

E.g. if you put `fields` on the top level instead of inside of `index`, we
know what you mean, so we can fix that.

This fixes it for both http and local.