### PR TITLE
add test for $elemMatch

### DIFF
--- a/bin/run-couch-master-on-travis.sh
+++ b/bin/run-couch-master-on-travis.sh
@@ -12,7 +12,7 @@ sudo dpkg -i esl-erlang_18.1-1~ubuntu~precise_amd64.deb
 # Sweet, build CouchDB
 git clone https://github.com/apache/couchdb.git ~/couchdb
 cd ~/couchdb
-./configure --disable-docs
+./configure --disable-docs --disable-fauxton
 make
 
 # All done, run a cluster

--- a/test/test-suite-1/index.js
+++ b/test/test-suite-1/index.js
@@ -37,6 +37,7 @@ module.exports = function (dbName, dbType, Pouch) {
     require('./test.errors')(dbType, context);
     require('./test.array')(dbType, context);
     require('./test.combinational')(dbType, context);
+    require('./test.elem-match')(dbType, context);
     require('./test.mod')(dbType, context);
     require('./test.regex')(dbType, context);
     require('./test.not')(dbType, context);

--- a/test/test-suite-1/test.elem-match.js
+++ b/test/test-suite-1/test.elem-match.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = function (dbType, context) {
+  describe(dbType + ': $elemMatch', function () {
+
+    beforeEach(function () {
+      return context.db.bulkDocs([
+        {'_id': 'peach', eats: ['cake', 'turnips', 'sweets']},
+        {'_id': 'sonic', eats: ['chili dogs']},
+        {'_id': 'fox',   eats: []},
+        {'_id': 'mario', eats: ['cake', 'mushrooms']},
+        {'_id': 'samus', eats: ['pellets']},
+        {'_id': 'kirby', eats: 'anything'}
+      ]);
+    });
+
+    it('basic test', function () {
+      var db = context.db;
+      var index = {index: {fields: ['eats']}};
+      return db.createIndex(index).then(function () {
+        return db.find({
+          selector: {eats: {$elemMatch: {$eq: 'cake'}}}
+        }).then(function (resp) {
+          resp.docs.map(function (doc) {
+            return doc._id;
+          }).sort().should.deep.equal(['mario', 'peach']);
+        });
+      });
+    });
+  });
+};

--- a/test/test-suite-1/test.elem-match.js
+++ b/test/test-suite-1/test.elem-match.js
@@ -1,29 +1,51 @@
 'use strict';
 
 module.exports = function (dbType, context) {
+
   describe(dbType + ': $elemMatch', function () {
+    if (dbType === 'http') { return;}
 
     beforeEach(function () {
       return context.db.bulkDocs([
-        {'_id': 'peach', eats: ['cake', 'turnips', 'sweets']},
-        {'_id': 'sonic', eats: ['chili dogs']},
+        {'_id': 'peach', eats: ['cake', 'turnips', 'sweets'], results: [ 82, 85, 88 ]},
+        {'_id': 'sonic', eats: ['chili dogs'], results: [ 75, 88, 89 ]},
         {'_id': 'fox',   eats: []},
         {'_id': 'mario', eats: ['cake', 'mushrooms']},
         {'_id': 'samus', eats: ['pellets']},
-        {'_id': 'kirby', eats: 'anything'}
+        {'_id': 'kirby', eats: 'anything', results: [ 82, 86, 10 ]}
       ]);
     });
 
     it('basic test', function () {
       var db = context.db;
-      var index = {index: {fields: ['eats']}};
+      var index = {index: {fields: ['_id']}};
       return db.createIndex(index).then(function () {
         return db.find({
-          selector: {eats: {$elemMatch: {$eq: 'cake'}}}
+          selector: {
+            _id: {$gt: 'a'},
+            eats: {$elemMatch: {$eq: 'cake'}}
+          }
         }).then(function (resp) {
           resp.docs.map(function (doc) {
             return doc._id;
           }).sort().should.deep.equal(['mario', 'peach']);
+        });
+      });
+    });
+
+    it('basic test with two operators', function () {
+      var db = context.db;
+      var index = {index: {fields: ['_id']}};
+      return db.createIndex(index).then(function () {
+        return db.find({
+          selector: {
+            _id: {$gt: 'a'},
+            results: {$elemMatch: {$gte: 80, $lt: 85}}
+          }
+        }).then(function (resp) {
+          resp.docs.map(function (doc) {
+            return doc._id;
+          }).should.deep.equal(['kirby', 'peach']);
         });
       });
     });


### PR DESCRIPTION
I started trying to implement $elemMatch, but the problem
I'm running into is that I can't get CouchDB to actually return
results. :(

This test fails; CouchDB returns a 400 error with:

```js
{"error":"no_usable_index","reason":"There is no index available for this selector."}
```