### PR TITLE
Use spark-md5 in all environments.

### DIFF
--- a/lib/abstract-mapreduce/utils.js
+++ b/lib/abstract-mapreduce/utils.js
@@ -92,14 +92,8 @@ exports.uniq = function (arr) {
   return output;
 };
 
-var crypto = require('crypto');
 var Md5 = require('spark-md5');
-
 exports.MD5 = function (string) {
-  /* istanbul ignore else */
-  if (!process.browser) {
-    return crypto.createHash('md5').update(string).digest('hex');
-  } else {
-    return Md5.hash(string);
-  }
+  return Md5.hash(string);
 };
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,16 +105,9 @@ exports.promisedCallback = function (promise, callback) {
   return promise;
 };
 
-var crypto = require('crypto');
 var Md5 = require('spark-md5');
-
 exports.MD5 = function (string) {
-  /* istanbul ignore else */
-  if (!process.browser) {
-    return crypto.createHash('md5').update(string).digest('hex');
-  } else {
-    return Md5.hash(string);
-  }
+  return Md5.hash(string);
 };
 
 exports.flatten = exports.getArguments(function (args) {


### PR DESCRIPTION
This (probably) has worse performance on node, but requiring crypto
breaks react-native's packager.