### PR TITLE
Use docker for couchdb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,25 @@
 language: node_js
+
 node_js:
-  - "5.4.1"
+  - "stable"
+
+services:
+  - docker
+
+sudo:
+  false
 
 addons:
   firefox: "41.0.1"
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - build-essential
-      - ca-certificates
-      - curl
-      - git
-      - libicu-dev
-      - libmozjs185-dev
-      - python
-      - g++
-      - g++-4.8
 
 before_install:
-  #haproxy is not on the apt approved list. So manually install
-  - sudo apt-get -y install haproxy
+  # Install CouchDB Master
+  - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --with-admin-party-please -n 1
 
 script: npm run $COMMAND
 
 before_script:
     # Install and run CouchDB master for http tests
-  - 'npm run install-couch'
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,14 @@ addons:
 before_install:
   # Install CouchDB Master
   - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --with-admin-party-please -n 1
+  - npm install add-cors-to-couchdb
+  - add-cors-to-couchdb
 
 script: npm run $COMMAND
 
 before_script:
-    # Install and run CouchDB master for http tests
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - "sleep 5"
-
-    # Workaround for Selenium #3280 issue
-  - "sudo sed -i 's/^127\\.0\\.0\\.1.*$/127.0.0.1 localhost/' /etc/hosts"
-
-after_failure:
-  - "curl -X GET http://127.0.0.1:5984/_log?bytes=1000000"
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
   # Install CouchDB Master
   - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --with-admin-party-please -n 1
   - npm install add-cors-to-couchdb
-  - add-cors-to-couchdb
+  - "while [ '200' != $(curl -s -o /dev/null -w \"%{http_code}\" 127.0.0.1:5984) ]; do echo waiting for couch to load... ; sleep 1; done"
+  - ./node_modules/.bin/add-cors-to-couchdb
 
 script: npm run $COMMAND
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "stable"
+  - "5"
 
 services:
   - docker


### PR DESCRIPTION
User docker for CouchDB 2.0 instead of manually installing it.