### PR TITLE
remove accidental debug output

### DIFF
--- a/lib/adapters/local/find/in-memory-filter.js
+++ b/lib/adapters/local/find/in-memory-filter.js
@@ -220,7 +220,6 @@ var matchers = {
     }
 
     if (docFieldValue.length === 0) {
-      console.log('FIELD WOOO!');
       return false;
     }
 


### PR DESCRIPTION
when handling $elemMatch, `FIELD WOO!` was logged to console.

Fixes #180 