### PR TITLE
Fields dot notation

### DIFF
--- a/lib/adapters/local/find/in-memory-filter.js
+++ b/lib/adapters/local/find/in-memory-filter.js
@@ -14,20 +14,7 @@ var getKey = localUtils.getKey;
 var getValue = localUtils.getValue;
 var parseField = localUtils.parseField;
 var utils = require('../../../utils');
-
-// this would just be "return doc[field]", but fields
-// can be "deep" due to dot notation
-function getFieldFromDoc(doc, parsedField) {
-  var value = doc;
-  for (var i = 0, len = parsedField.length; i < len; i++) {
-    var key = parsedField[i];
-    value = value[key];
-    if (!value) {
-      break;
-    }
-  }
-  return value;
-}
+var getFieldFromDoc = utils.getFieldFromDoc;
 
 // create a comparator based on the sort object
 function createFieldSorter(sort) {

--- a/lib/adapters/local/utils.js
+++ b/lib/adapters/local/utils.js
@@ -310,27 +310,6 @@ function validateFindRequest(requestDef) {
   }
 }
 
-function parseField(fieldName) {
-  // fields may be deep (e.g. "foo.bar.baz"), so parse
-  var fields = [];
-  var current = '';
-  for (var i = 0, len = fieldName.length; i < len; i++) {
-    var ch = fieldName[i];
-    if (ch === '.') {
-      if (i > 0 && fieldName[i - 1] === '\\') { // escaped delimiter
-        current = current.substring(0, current.length - 1) + '.';
-      } else { // not escaped, so delimiter
-        fields.push(current);
-        current = '';
-      }
-    } else { // normal character
-      current += ch;
-    }
-  }
-  fields.push(current);
-  return fields;
-}
-
 // determine the maximum number of fields
 // we're going to need to query, e.g. if the user
 // has selection ['a'] and sorting ['a', 'b'], then we
@@ -380,7 +359,7 @@ module.exports = {
   reverseOptions: reverseOptions,
   filterInclusiveStart: filterInclusiveStart,
   massageIndexDef: massageIndexDef,
-  parseField: parseField,
+  parseField: utils.parseField,
   getUserFields: getUserFields,
   isCombinationalField: isCombinationalField
 };

--- a/test/test-suite-1/index.js
+++ b/test/test-suite-1/index.js
@@ -30,6 +30,7 @@ module.exports = function (dbName, dbType, Pouch) {
     require('./test.ltgt')(dbType, context);
     require('./test.eq')(dbType, context);
     require('./test.deep-fields')(dbType, context);
+    require('./test.pick-fields')(dbType, context);
     require('./test.exists')(dbType, context);
     require('./test.type')(dbType, context);
     require('./test.ne')(dbType, context);

--- a/test/test-suite-1/test.pick-fields.js
+++ b/test/test-suite-1/test.pick-fields.js
@@ -1,0 +1,75 @@
+'use strict';
+
+module.exports = function (dbType, context) {
+
+  describe(dbType + ': pick fields', function () {
+
+    it('should pick shallow fields', function () {
+      var db = context.db;
+      return db.bulkDocs([
+        { name: 'Mario', _id: 'mario', series: 'Mario', debut: {year: 1981, month: 'May'}  },
+        { name: 'Jigglypuff', _id: 'puff', series: 'Pokemon', debut: {year: 1996, month: 'June'} },
+        { name: 'Link', _id: 'link', series: 'Zelda', debut: {year: 1986, month: 'July'} },
+        { name: 'Donkey Kong', _id: 'dk', series: 'Mario', debut: {year: 1981, month: 'April'} },
+        { name: 'Pikachu', series: 'Pokemon', _id: 'pikachu',
+          debut: {year: 1996, month: 'September'} },
+        { name: 'Captain Falcon', _id: 'falcon', series: 'F-Zero',
+          debut: {year: 1990, month: 'December'} }
+      ]).then(function () {
+        return db.find({
+          selector: {_id: {$gt: null}},
+          sort: ['_id'],
+          fields: ['name']
+        });
+      }).then(function (res) {
+        res.docs.should.deep.equal([
+          { name: 'Donkey Kong' },
+          { name: 'Captain Falcon' },
+          { name: 'Link' },
+          { name: 'Mario' },
+          { name: 'Pikachu' },
+          { name: 'Jigglypuff' } ]);
+      });
+    });
+    
+    it('should pick deep fields', function () {
+      var db = context.db;
+      return db.bulkDocs([
+        {_id: 'a', foo: {bar: 'yo'}, bar: {baz: 'hey'}},
+        {_id: 'b', foo: {bar: 'sup'}, bar: {baz: 'dawg'}},
+        {_id: 'c', foo: true, bar: "yo"},
+        {_id: 'd', foo: null, bar: []}
+      ]).then(function () {
+        return db.find({
+          selector: {_id: {$gt: null}},
+          sort: ['_id'],
+          fields: ['_id', 'bar.baz']
+        });
+      }).then(function (res) {
+        res.docs.should.deep.equal([
+          { _id: 'a', bar: { baz: 'hey' } },
+          { _id: 'b', bar: { baz: 'dawg' } },
+          { _id: 'c' },
+          { _id: 'd' } ]);
+      });
+    });
+
+    it('should pick really deep fields with escape', function () {
+      var db = context.db;
+      return db.bulkDocs([
+        {_id: 'a', really: {deeply: {nested: {'escaped.field': 'You found me!'}}}}
+      ]).then(function () {
+        return db.find({
+          selector: {_id: {$gt: null}},
+          fields: ['really.deeply.nested.escaped\\.field']
+        });
+      }).then(function (res) {
+        res.docs.should.deep.equal([
+          { really: { deeply: { nested: { 'escaped.field': 'You found me!' } } } }
+        ]);
+      });
+    });
+    
+  });
+  
+};


### PR DESCRIPTION
Added support for nested fields using dot notation with '\\' escape in the `fields` option. Also added tests.
This resolves #164 .