### PR TITLE
Fix createIndex doesn't "do nothing"

### DIFF
--- a/lib/adapters/local/create-index/index.js
+++ b/lib/adapters/local/create-index/index.js
@@ -40,6 +40,10 @@ function createIndex(db, requestDef) {
 
     viewExists = !!doc.views[viewName];
 
+    if (viewExists) {
+      return false;
+    }
+
     doc.views[viewName] = {
       map: {
         fields: utils.mergeObjects(requestDef.index.fields)

--- a/test/test-suite-1/test.basic.js
+++ b/test/test-suite-1/test.basic.js
@@ -46,7 +46,7 @@ module.exports = function (dbType, context) {
       }).then(function (response) {
         response.id.should.match(/^_design\//);
         response.name.should.equal('foo-index');
-        //response.result.should.equal('exists');
+        response.result.should.equal('exists');
         return response.id;
       }).then(function (ddocId) {
         return db.get(ddocId);

--- a/test/test-suite-1/test.basic.js
+++ b/test/test-suite-1/test.basic.js
@@ -29,6 +29,32 @@ module.exports = function (dbType, context) {
       });
     });
 
+    it('should not update an existing index', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": ["foo"]
+        },
+        "name": "foo-index",
+        "type": "json"
+      };
+      return db.createIndex(index).then(function (response) {
+        response.id.should.match(/^_design\//);
+        response.name.should.equal('foo-index');
+        response.result.should.equal('created');
+        return db.createIndex(index);
+      }).then(function (response) {
+        response.id.should.match(/^_design\//);
+        response.name.should.equal('foo-index');
+        //response.result.should.equal('exists');
+        return response.id;
+      }).then(function (ddocId) {
+        return db.get(ddocId);
+      }).then(function (doc) {
+        doc._rev.slice(0, 1).should.equal('1');
+      });
+    });
+
     it('throws an error for an invalid index creation', function () {
       var db = context.db;
       return db.createIndex('yo yo yo').then(function () {


### PR DESCRIPTION
According to the README, `createIndex` should:

> Create an index if it doesn't exist, or do nothing if it already exists.

 Therefore, I added a test to make sure that nothing happens if the index exists. This test fails, the document is being updated, and the revision number is incrementing.

Returning `false` from the `updateDdoc` function if a view already exists will give us our desired behaviour.

**Note:** I did **not** commit the updated `/dist` files as other PRs didn't and I assumed it was part of a deploy process. I **can** commit these changes if need be.

Resolves #161