### PR TITLE
fixes non-memory lt/gt in conjunction with limit

### DIFF
--- a/lib/adapters/local/find/index.js
+++ b/lib/adapters/local/find/index.js
@@ -94,7 +94,8 @@ function find(db, requestDef) {
       // no in-memory filtering necessary, so we can let the
       // database do the limit/skip for us
       if ('limit' in requestDef) {
-        opts.limit = requestDef.limit;
+        // increase limit since couchdb has no true inclusive_start option
+        opts.limit = (opts.inclusive_start === false) ? requestDef.limit + 1 : requestDef.limit;
       }
       if ('skip' in requestDef) {
         opts.skip = requestDef.skip;
@@ -114,6 +115,9 @@ function find(db, requestDef) {
         // may have to manually filter the first one,
         // since couchdb has no true inclusive_start option
         res.rows = filterInclusiveStart(res.rows, opts.startkey, indexToUse);
+        if ('limit' in requestDef && res.rows.length > requestDef.limit) {
+          res.rows.pop();
+        }
       }
 
       if (queryPlan.inMemoryFields.length) {

--- a/test/test-suite-1/index.js
+++ b/test/test-suite-1/index.js
@@ -51,5 +51,6 @@ module.exports = function (dbName, dbType, Pouch) {
     require('./test.issue66')(dbType, context);
     require('./test.and')(dbType, context);
     require('./test.default-index')(dbType, context);
+    require('./test.ltgt-limit')(dbType, context);
   });
 };

--- a/test/test-suite-1/test.ltgt-limit.js
+++ b/test/test-suite-1/test.ltgt-limit.js
@@ -1,0 +1,347 @@
+'use strict';
+
+module.exports = function (dbType, context) {
+
+  describe(dbType + ': ltgt with limit', function () {
+    it('#20 - lt queries with sort descending return correct number of docs', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": ["debut"]
+        },
+        "name": "foo-index",
+        "type": "json"
+      };
+
+      return db.createIndex(index).then(function () {
+        return db.bulkDocs([
+          { _id: '1', debut: 1983},
+          { _id: '2', debut: 1981},
+          { _id: '3', debut: 1989},
+          { _id: '4', debut: 1990}
+        ]);
+      }).then(function () {
+        return db.find({
+          selector: {debut: {$lt: 1990}},
+          sort: [{debut: 'desc'}],
+          limit: 1
+        });
+      }).then(function (resp) {
+        var docs = resp.docs.map(function (x) { delete x._rev; return x; });
+        docs.should.deep.equal([
+          { _id: '3', debut: 1989}
+        ]);
+      });
+    });
+    // ltge - {include_docs: true, reduce: false, descending: true, startkey: 1990}
+    // lt no sort {include_docs: true, reduce: false, endkey: 1990, inclusive_end: false}
+    // lt sort {include_docs: true, reduce: false, descending: true, 
+    // startkey: 1990, inclusive_start: false}
+
+    it('#38 $gt with dates', function () {
+      var db = context.db;
+
+      var startDate = "2015-05-25T00:00:00.000Z";
+      var endDate = "2015-05-26T00:00:00.000Z";
+
+      return db.createIndex({
+        index: {
+          fields: ['docType', 'logDate']
+        }
+      }).then(function () {
+        return db.bulkDocs([
+          {_id: '1', docType: 'log', logDate: "2015-05-24T00:00:00.000Z"},
+          {_id: '2', docType: 'log', logDate: "2015-05-25T00:00:00.000Z"},
+          {_id: '3', docType: 'log', logDate: "2015-05-26T00:00:00.000Z"},
+          {_id: '4', docType: 'log', logDate: "2015-05-27T00:00:00.000Z"}
+        ]);
+      }).then(function() {
+        return db.find({
+          selector: {docType: 'log'}
+        }).then(function (result) {
+          result.docs.map(function (x) { delete x._rev; return x; }).should.deep.equal([
+            {
+              "_id": "1",
+              "docType": "log",
+              "logDate": "2015-05-24T00:00:00.000Z"
+            },
+            {
+              "_id": "2",
+              "docType": "log",
+              "logDate": "2015-05-25T00:00:00.000Z"
+            },
+            {
+              "_id": "3",
+              "docType": "log",
+              "logDate": "2015-05-26T00:00:00.000Z"
+            },
+            {
+              "_id": "4",
+              "docType": "log",
+              "logDate": "2015-05-27T00:00:00.000Z"
+            }
+          ], 'test 1');
+        });
+      }).then(function () {
+        return db.find({
+          selector: {docType: 'log', logDate: {$gt: startDate}},
+          limit: 1
+        }).then(function (result) {
+          result.docs.map(function (x) { delete x._rev; return x; }).should.deep.equal([
+            {
+              "_id": "3",
+              "docType": "log",
+              "logDate": "2015-05-26T00:00:00.000Z"
+            }
+          ], 'test 2');
+        });
+      }).then(function () {
+        return db.find({
+          selector: {docType: 'log', logDate: {$gte: startDate}},
+          limit: 1
+        }).then(function (result) {
+          result.docs.map(function (x) { delete x._rev; return x; }).should.deep.equal([
+            {
+              "_id": "2",
+              "docType": "log",
+              "logDate": "2015-05-25T00:00:00.000Z"
+            }
+          ], 'test 3');
+        });
+      }).then(function () {
+        return db.find({
+          selector: {
+            docType: 'log',
+            logDate: {$gte: startDate, $lte: endDate}
+          },
+          limit: 1
+        }).then(function (result) {
+          result.docs.map(function (x) { delete x._rev; return x; }).should.deep.equal([
+            {
+              "_id": "2",
+              "docType": "log",
+              "logDate": "2015-05-25T00:00:00.000Z"
+            }
+          ], 'test 4');
+        });
+      });
+    });
+
+    it('bunch of equivalent queries', function () {
+      var db = context.db;
+
+      function normalize(res) {
+        return res.docs.map(function getId(x) {
+          return x._id;
+        }).sort();
+      }
+
+      return db.createIndex({
+        index: {
+          fields: ['foo']
+        }
+      }).then(function () {
+        return db.bulkDocs([
+          {_id: '1', foo: 1},
+          {_id: '2', foo: 2},
+          {_id: '3', foo: 3},
+          {_id: '4', foo: 4}
+        ]);
+      }).then(function() {
+        return db.find({
+          selector: { $and: [{foo: {$gt: 2}}, {foo: {$gte: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['3']);
+        return db.find({
+          selector: { $and: [{foo: {$eq: 2}}, {foo: {$gte: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['2']);
+        return db.find({
+          selector: { $and: [{foo: {$eq: 2}}, {foo: {$lte: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['2']);
+        return db.find({
+          selector: { $and: [{foo: {$lte: 3}}, {foo: {$lt: 3}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$eq: 4}}, {foo: {$gte: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['4']);
+        return db.find({
+          selector: { $and: [{foo: {$lte: 3}}, {foo: {$eq: 1}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$eq: 4}}, {foo: {$gt: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['4']);
+        return db.find({
+          selector: { $and: [{foo: {$lt: 3}}, {foo: {$eq: 1}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+      });
+    });
+
+    it('bunch of equivalent queries 2', function () {
+      var db = context.db;
+
+      function normalize(res) {
+        return res.docs.map(function getId(x) {
+          return x._id;
+        }).sort();
+      }
+
+      return db.createIndex({
+        index: {
+          fields: ['foo']
+        }
+      }).then(function () {
+        return db.bulkDocs([
+          {_id: '1', foo: 1},
+          {_id: '2', foo: 2},
+          {_id: '3', foo: 3},
+          {_id: '4', foo: 4}
+        ]);
+      }).then(function() {
+        return db.find({
+          selector: { $and: [{foo: {$gt: 2}}, {foo: {$gte: 1}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['3']);
+        return db.find({
+          selector: { $and: [{foo: {$lt: 3}}, {foo: {$lte: 4}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$gt: 2}}, {foo: {$gte: 3}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['3']);
+        return db.find({
+          selector: { $and: [{foo: {$lt: 3}}, {foo: {$lte: 1}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$gte: 2}}, {foo: {$gte: 1}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['2']);
+        return db.find({
+          selector: { $and: [{foo: {$lte: 3}}, {foo: {$lte: 4}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$gt: 2}}, {foo: {$gt: 3}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['4']);
+        return db.find({
+          selector: { $and: [{foo: {$lt: 3}}, {foo: {$lt: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+      });
+    });
+
+    it('bunch of equivalent queries 3', function () {
+      var db = context.db;
+
+      function normalize(res) {
+        return res.docs.map(function getId(x) {
+          return x._id;
+        }).sort();
+      }
+
+      return db.createIndex({
+        index: {
+          fields: ['foo']
+        }
+      }).then(function () {
+        return db.bulkDocs([
+          {_id: '1', foo: 1},
+          {_id: '2', foo: 2},
+          {_id: '3', foo: 3},
+          {_id: '4', foo: 4}
+        ]);
+      }).then(function() {
+        return db.find({
+          selector: { $and: [{foo: {$gte: 1}}, {foo: {$gt: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['3']);
+        return db.find({
+          selector: { $and: [{foo: {$lte: 4}}, {foo: {$lt: 3}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$gte: 3}}, {foo: {$gt: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['3']);
+        return db.find({
+          selector: { $and: [{foo: {$lte: 1}}, {foo: {$lt: 3}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$gte: 1}}, {foo: {$gte: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['2']);
+        return db.find({
+          selector: { $and: [{foo: {$lte: 4}}, {foo: {$lte: 3}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+        return db.find({
+          selector: { $and: [{foo: {$gt: 3}}, {foo: {$gt: 2}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['4']);
+        return db.find({
+          selector: { $and: [{foo: {$lt: 2}}, {foo: {$lt: 3}}]},
+          limit: 1
+        });
+      }).then(function (res) {
+        normalize(res).should.deep.equal(['1']);
+      });
+    });
+
+  });
+};

--- a/test/test-suite-1/test.ltgt-limit.js
+++ b/test/test-suite-1/test.ltgt-limit.js
@@ -3,6 +3,34 @@
 module.exports = function (dbType, context) {
 
   describe(dbType + ': ltgt with limit', function () {
+    it('gt query return correct number of docs', function () {
+      var db = context.db;
+      var index = {
+        "index": {
+          "fields": ["number"]
+        },
+        "name": "number-index",
+        "type": "json"
+      };
+
+      return db.createIndex(index).then(function () {
+        return db.bulkDocs([
+          { _id: '0', number: 0 },
+          { _id: '1', number: 1 }
+        ]);
+      }).then(function () {
+        return db.find({
+          selector: { number: { $gt: -1 } },
+          limit: 1
+        });
+      }).then(function (resp) {
+        var docs = resp.docs.map(function (x) { delete x._rev; return x; });
+        docs.should.deep.equal([
+          { _id: '0', number: 0 }
+        ]);
+      });
+    });
+
     it('#20 - lt queries with sort descending return correct number of docs', function () {
       var db = context.db;
       var index = {


### PR DESCRIPTION
Hello, please consider following example:

```
var index = {
  "index": {
    "fields": ["type", "number"]
  },
  "name": "foo-index",
  "type": "json"
};

db.createIndex(index).then(function (res) {
  return db.bulkDocs([
    { _id: "0", number: 0, type: "doc" },
    { _id: "1", number: 1, type: "doc" }
  ]);
}).then(function () {
  return db.find({
    selector: { type: { $eq: "doc" }, number: { $gt: 0 } },
    limit: 1 // limit = 1 gives 0 results / limit = 2 leads to inclusion of doc#1
  });
}).then(function (res) {
  console.log(res.docs.length); // is: 0 / expected: 1 
})
```

Problem is, mapping for non-in-memory filtering requests a start-key of 0 for field "number" and a limit of 1 - which only returns doc#_id:0.
My fix is simple as can be. Also the according tests. I simply copied "test.ltgt.js", added a "limit" option and left all tests from the original which failed.