### PR TITLE
adds the ability to select the index you want

### DIFF
--- a/lib/adapters/local/find/index.js
+++ b/lib/adapters/local/find/index.js
@@ -61,9 +61,9 @@ function find(db, requestDef) {
 
   validateFindRequest(requestDef);
 
-  return getIndexes(db).then(function (getIndexesRes) {
+  return getIndexes(db, requestDef.indexName).then(function (getIndexesRes) {
 
-    var queryPlan = planQuery(requestDef, getIndexesRes.indexes);
+    var queryPlan = planQuery(requestDef, getIndexesRes.indexes, requestDef.indexName);
 
     var indexToUse = queryPlan.index;
 

--- a/lib/adapters/local/find/query-planner.js
+++ b/lib/adapters/local/find/query-planner.js
@@ -408,7 +408,7 @@ function getCoreQueryPlan(selector, index) {
   return getMultiFieldQueryOpts(selector, index);
 }
 
-function planQuery(request, indexes) {
+function planQuery(request, indexes, indexName) {
 
   log('planning query', request);
 
@@ -419,7 +419,18 @@ function planQuery(request, indexes) {
 
   var userFields = userFieldsRes.fields;
   var sortOrder = userFieldsRes.sortOrder;
-  var index = findBestMatchingIndex(selector, userFields, sortOrder, indexes);
+  var index;
+  if(indexName) {
+    for(var i = 0; i < indexes.length; i++) {
+      if(indexes[i].ddoc === '_design/'+indexName) {
+        index = indexes[i];
+        break;
+      }
+    }
+  }
+  if(!index) {
+    index = findBestMatchingIndex(selector, userFields, sortOrder, indexes);
+  }
 
   var coreQueryPlan = getCoreQueryPlan(selector, index);
   var queryOpts = coreQueryPlan.queryOpts;

--- a/lib/adapters/local/get-indexes/index.js
+++ b/lib/adapters/local/get-indexes/index.js
@@ -5,14 +5,24 @@ var utils = require('../../../utils');
 var localUtils = require('../utils');
 var massageIndexDef = localUtils.massageIndexDef;
 
-function getIndexes(db) {
+function getIndexes(db, indexName) {
+  var promise;
+  if(!indexName) {
+    promise = db.allDocs({
+      startkey: '_design/',
+      endkey: '_design/\uffff',
+      include_docs: true
+    });
+  } else {
+    promise = db.allDocs({
+      startkey: ('_design/'+indexName),
+      endkey: ('_design/' + indexName + '\uffff'),
+      include_docs: true
+    });
+  }
   // just search through all the design docs and filter in-memory.
   // hopefully there aren't that many ddocs.
-  return db.allDocs({
-    startkey: '_design/',
-    endkey: '_design/\uffff',
-    include_docs: true
-  }).then(function (allDocsRes) {
+  return promise.then(function (allDocsRes) {
     var res = {
       indexes: [{
         ddoc: null,


### PR DESCRIPTION
sometimes the automatic index selector selects the wrong index this gives you the freedom to select the index you want by adding an indexName field to the options. if you do not provide an indexName nothing will change, i.e. the query will run the same way as before.

example options:

      var options = {
        selector: { someField:'someValue',anotherField:'anotherValue' },
        sort: [{ someField:'desc' }],
        limit: queryLimit,
        indexName: 'someIndex'
      };
