### PR TITLE
UPDATE spark-md5 to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "pouchdb-extend": "^0.1.2",
     "pouchdb-promise": "5.4.0",
     "pouchdb-upsert": "~2.0.1",
-    "spark-md5": "0.0.5"
+    "spark-md5": "2.0.2"
   },
   "devDependencies": {
     "bluebird": "^1.0.7",


### PR DESCRIPTION
Hi. Can we update spark-md5 to the newest version 2.0.2 ?

PouchDB [itself](https://github.com/pouchdb/pouchdb/blob/master/package.json#L53) uses this version and therefore I also want to use it in my own module so that i can minimize the build-size by reusing the import.

Maybe it would be better to require pouchdb-md5 instead of adding the hashing by pouchdb-find itself.
