### PR TITLE
Update website to use latest Pouch/pouchdb-find

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,8 +187,8 @@
 <script src="www/ace/ace.js"></script>
 <script src="www/handlebars/handlebars-v2.0.0.js"></script>
 <script src="www/handlebars/handlebars.runtime-v2.0.0.js"></script>
-<script src="www/pouchdb-3.2.2-prerelease.js"></script>
-<script src="dist/pouchdb.find.js"></script>
+<script src="https://unpkg.com/pouchdb/dist/pouchdb.min.js"></script>
+<script src="https://unpkg.com/pouchdb-find/dist/pouchdb.find.min.js"></script>
 <script id="smashers-template" type="text/x-handlebars-template">
   <div class="row">
     <div class="col-xs-1">


### PR DESCRIPTION
This PR is just for an FYI; I'm going to merge immediately to get this fixed.

Uses the latest live version on unpkg for both PouchDB and pouchdb-find.