### PR TITLE
fix: update unpkg urls in pouchdb.find demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,8 +187,8 @@
 <script src="www/ace/ace.js"></script>
 <script src="www/handlebars/handlebars-v2.0.0.js"></script>
 <script src="www/handlebars/handlebars.runtime-v2.0.0.js"></script>
-<script src="https://unpkg.com/pouchdb/dist/pouchdb.min.js"></script>
-<script src="https://unpkg.com/pouchdb-find/dist/pouchdb.find.min.js"></script>
+<script src="https://unpkg.com/pouchdb@6.2.0/dist/pouchdb.js"></script>
+<script src="https://unpkg.com/pouchdb@6.2.0/dist/pouchdb.find.js"></script>
 <script id="smashers-template" type="text/x-handlebars-template">
   <div class="row">
     <div class="col-xs-1">


### PR DESCRIPTION
Hi Nolan 👋  

I know this one’s technically deprecated, but there are reasons! The CDN urls on the `pouchdb.find` demo page (https://nolanlawson.github.io/pouchdb-find/) were broken, and I thought this was worth fixing, because:
- The PouchDB docs and a few blog posts still link there
- It’s a great (actually, the only) resource to just try out Mango quickly without installing anything
- Yoshi!

Thanks for all your hard work! 
